### PR TITLE
1.9.1 - Better Error Handling and Squiz Clarity

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>space.alphaserpentis</groupId>
     <artifactId>SqueethDiscordBot</artifactId>
-    <version>1.9</version>
+    <version>1.10-test</version>
 
     <properties>
         <maven.compiler.source>14</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>space.alphaserpentis</groupId>
     <artifactId>SqueethDiscordBot</artifactId>
-    <version>1.10-test</version>
+    <version>1.9.1</version>
 
     <properties>
         <maven.compiler.source>14</maven.compiler.source>

--- a/src/main/java/space/alphaserpentis/squeethdiscordbot/commands/BotCommand.java
+++ b/src/main/java/space/alphaserpentis/squeethdiscordbot/commands/BotCommand.java
@@ -77,7 +77,7 @@ public abstract class BotCommand<T> {
     }
 
     @Nonnull
-    public static Message handleReply(@Nonnull SlashCommandInteractionEvent event, BotCommand<?> cmd) {
+    public static Message handleReply(@Nonnull SlashCommandInteractionEvent event, @Nonnull BotCommand<?> cmd) {
         boolean sendAsEphemeral = cmd.isOnlyEphemeral();
         Object response;
         ReplyCallbackAction reply;
@@ -97,7 +97,7 @@ public abstract class BotCommand<T> {
                 response = cmd.isActive() ? cmd.runCommand(event.getUser().getIdLong(), event) : inactiveCommandResponse();
 
                 if (cmd instanceof ButtonCommand) {
-                    Collection<ItemComponent> buttons = ((ButtonCommand) cmd).addButtons(event);
+                    Collection<ItemComponent> buttons = ((ButtonCommand<?>) cmd).addButtons(event);
 
                     if (cmd.isUsingRatelimits() && !cmd.isUserRatelimited(event.getUser().getIdLong())) {
                         cmd.ratelimitMap.put(event.getUser().getIdLong(), Instant.now().getEpochSecond() + cmd.ratelimitLength);
@@ -144,16 +144,16 @@ public abstract class BotCommand<T> {
         }
 
         if (cmd instanceof ButtonCommand) {
-            Collection<ItemComponent> buttons = ((ButtonCommand) cmd).addButtons(event);
+            Collection<ItemComponent> buttons = ((ButtonCommand<?>) cmd).addButtons(event);
 
             if(!buttons.isEmpty())
-                reply.addActionRow(buttons);
+                reply = reply.addActionRow(buttons);
         }
 
         return reply.complete().retrieveOriginal().complete();
     }
 
-    protected static void letMessageExpire(@Nonnull BotCommand<?> command, Message message) {
+    protected static void letMessageExpire(@Nonnull BotCommand<?> command, @Nonnull Message message) {
         if(command.doMessagesExpire()) {
             new Thread(
                     () -> {

--- a/src/main/java/space/alphaserpentis/squeethdiscordbot/commands/BotCommand.java
+++ b/src/main/java/space/alphaserpentis/squeethdiscordbot/commands/BotCommand.java
@@ -84,73 +84,81 @@ public abstract class BotCommand<T> {
 
         if (cmd.isDeferReplies()) {
             InteractionHook hook = event.getHook();
-            if (!sendAsEphemeral && event.getGuild() != null) {
-                sendAsEphemeral = ServerDataHandler.serverDataHashMap.get(event.getGuild().getIdLong()).isOnlyEphemeral();
-            }
-
-            if (cmd.isOnlyEmbed()) {
+            try {
                 if (!sendAsEphemeral && event.getGuild() != null) {
-                    event.deferReply(false).complete();
-                } else {
-                    event.deferReply(sendAsEphemeral).complete();
+                    sendAsEphemeral = ServerDataHandler.serverDataHashMap.get(event.getGuild().getIdLong()).isOnlyEphemeral();
                 }
-                response = cmd.isActive() ? cmd.runCommand(event.getUser().getIdLong(), event) : inactiveCommandResponse();
 
-                if (cmd instanceof ButtonCommand) {
-                    Collection<ItemComponent> buttons = ((ButtonCommand<?>) cmd).addButtons(event);
+                if (cmd.isOnlyEmbed()) {
+                    if (!sendAsEphemeral && event.getGuild() != null) {
+                        event.deferReply(false).complete();
+                    } else {
+                        event.deferReply(sendAsEphemeral).complete();
+                    }
+                    response = cmd.isActive() ? cmd.runCommand(event.getUser().getIdLong(), event) : inactiveCommandResponse();
+
+                    if (cmd instanceof ButtonCommand) {
+                        Collection<ItemComponent> buttons = ((ButtonCommand<?>) cmd).addButtons(event);
+
+                        if (cmd.isUsingRatelimits() && !cmd.isUserRatelimited(event.getUser().getIdLong())) {
+                            cmd.ratelimitMap.put(event.getUser().getIdLong(), Instant.now().getEpochSecond() + cmd.ratelimitLength);
+                        }
+
+                        if(!buttons.isEmpty())
+                            return hook.sendMessageEmbeds((MessageEmbed) response).addActionRow(buttons).complete();
+                    }
 
                     if (cmd.isUsingRatelimits() && !cmd.isUserRatelimited(event.getUser().getIdLong())) {
                         cmd.ratelimitMap.put(event.getUser().getIdLong(), Instant.now().getEpochSecond() + cmd.ratelimitLength);
                     }
 
-                    if(!buttons.isEmpty())
-                        return hook.sendMessageEmbeds((MessageEmbed) response).addActionRow(buttons).complete();
-                }
+                    return hook.sendMessageEmbeds((MessageEmbed) response).complete();
+                } else {
+                    if (!sendAsEphemeral && event.getGuild() != null) {
+                        hook.setEphemeral(false);
+                    } else {
+                        hook.setEphemeral(sendAsEphemeral);
+                    }
+                    response = cmd.isActive() ? cmd.runCommand(event.getUser().getIdLong(), event) : inactiveCommandResponse();
 
-                if (cmd.isUsingRatelimits() && !cmd.isUserRatelimited(event.getUser().getIdLong())) {
-                    cmd.ratelimitMap.put(event.getUser().getIdLong(), Instant.now().getEpochSecond() + cmd.ratelimitLength);
+                    return hook.sendMessage((String) response).complete();
                 }
+            } catch(Exception e) {
+                return hook.sendMessageEmbeds(handleError(e)).complete();
+            }
+        }
 
-                return hook.sendMessageEmbeds((MessageEmbed) response).complete();
+        try {
+            response = cmd.isActive() ? cmd.runCommand(event.getUser().getIdLong(), event) : inactiveCommandResponse();
+
+            if (!sendAsEphemeral && event.getGuild() != null)
+                sendAsEphemeral = ServerDataHandler.serverDataHashMap.get(event.getGuild().getIdLong()).isOnlyEphemeral();
+
+            if (cmd.isOnlyEmbed()) {
+                if (!sendAsEphemeral && event.getGuild() != null) {
+                    reply = event.replyEmbeds((MessageEmbed) response).setEphemeral(false);
+                } else {
+                    reply = event.replyEmbeds((MessageEmbed) response).setEphemeral(sendAsEphemeral);
+                }
             } else {
                 if (!sendAsEphemeral && event.getGuild() != null) {
-                    hook.setEphemeral(false);
+                    reply = event.reply((Message) response).setEphemeral(false);
                 } else {
-                    hook.setEphemeral(sendAsEphemeral);
+                    reply = event.reply((Message) response).setEphemeral(sendAsEphemeral);
                 }
-                response = cmd.isActive() ? cmd.runCommand(event.getUser().getIdLong(), event) : inactiveCommandResponse();
-
-                return hook.sendMessage((String) response).complete();
             }
-        }
 
-        response = cmd.isActive() ? cmd.runCommand(event.getUser().getIdLong(), event) : inactiveCommandResponse();
+            if (cmd instanceof ButtonCommand) {
+                Collection<ItemComponent> buttons = ((ButtonCommand<?>) cmd).addButtons(event);
 
-        if (!sendAsEphemeral && event.getGuild() != null)
-            sendAsEphemeral = ServerDataHandler.serverDataHashMap.get(event.getGuild().getIdLong()).isOnlyEphemeral();
-
-        if (cmd.isOnlyEmbed()) {
-            if (!sendAsEphemeral && event.getGuild() != null) {
-                reply = event.replyEmbeds((MessageEmbed) response).setEphemeral(false);
-            } else {
-                reply = event.replyEmbeds((MessageEmbed) response).setEphemeral(sendAsEphemeral);
+                if(!buttons.isEmpty())
+                    reply = reply.addActionRow(buttons);
             }
-        } else {
-            if (!sendAsEphemeral && event.getGuild() != null) {
-                reply = event.reply((Message) response).setEphemeral(false);
-            } else {
-                reply = event.reply((Message) response).setEphemeral(sendAsEphemeral);
-            }
+
+            return reply.complete().retrieveOriginal().complete();
+        } catch(Exception e) {
+            return event.replyEmbeds(handleError(e)).setEphemeral(true).complete().retrieveOriginal().complete();
         }
-
-        if (cmd instanceof ButtonCommand) {
-            Collection<ItemComponent> buttons = ((ButtonCommand<?>) cmd).addButtons(event);
-
-            if(!buttons.isEmpty())
-                reply = reply.addActionRow(buttons);
-        }
-
-        return reply.complete().retrieveOriginal().complete();
     }
 
     protected static void letMessageExpire(@Nonnull BotCommand<?> command, @Nonnull Message message) {
@@ -166,6 +174,21 @@ public abstract class BotCommand<T> {
                     }
             ).start();
         }
+    }
+
+    @Nonnull
+    private static MessageEmbed handleError(@Nonnull Exception e) {
+        EmbedBuilder eb = new EmbedBuilder();
+
+        eb.setTitle("Command Failed To Execute");
+        eb.setDescription("The command failed to execute due to: " + e.getClass().getSimpleName());
+        if(e.getMessage().length() > 1800) {
+            eb.addField("Error Message", "Error too long...", false);
+        } else {
+            eb.addField("Error Message", e.getMessage(), false);
+        }
+
+        return eb.build();
     }
 
     @Nonnull

--- a/src/main/java/space/alphaserpentis/squeethdiscordbot/commands/ButtonCommand.java
+++ b/src/main/java/space/alphaserpentis/squeethdiscordbot/commands/ButtonCommand.java
@@ -13,7 +13,7 @@ import java.util.Collection;
 import java.util.HashMap;
 
 public abstract class ButtonCommand<T> extends BotCommand<T> {
-    protected HashMap<String, Button> buttonHashMap = new HashMap<>();
+    protected final HashMap<String, Button> buttonHashMap = new HashMap<>();
 
     abstract public void runButtonInteraction(@Nonnull ButtonInteractionEvent event);
     abstract public Collection<ItemComponent> addButtons(@Nonnull GenericCommandInteractionEvent event);

--- a/src/main/java/space/alphaserpentis/squeethdiscordbot/commands/Clean.java
+++ b/src/main/java/space/alphaserpentis/squeethdiscordbot/commands/Clean.java
@@ -54,7 +54,7 @@ public class Clean extends BotCommand<MessageEmbed> {
 
     }
 
-    private boolean verifyServerPerms(Member member) {
+    private boolean verifyServerPerms(@Nonnull Member member) {
         return member.hasPermission(
                 Permission.MESSAGE_MANAGE
         );

--- a/src/main/java/space/alphaserpentis/squeethdiscordbot/commands/Position.java
+++ b/src/main/java/space/alphaserpentis/squeethdiscordbot/commands/Position.java
@@ -91,14 +91,14 @@ public class Position extends ButtonCommand<MessageEmbed> {
         public BigInteger currentValueInEth;
         public BigInteger currentValueInUsd;
 
-        public AbstractPositions(String userAddress) {
+        public AbstractPositions(@Nonnull String userAddress) {
             this.userAddress = userAddress;
         }
 
         /**
          * Obtains the transfers of the given token for userAddress
          */
-        public void getAndSetTransfers(String tokenAddress) {
+        public void getAndSetTransfers(@Nonnull String tokenAddress) {
             // Check caches to see if we have the data
             if(PositionsDataHandler.cachedTransfers.containsKey(userAddress)) {
                 if(PositionsDataHandler.cachedTransfers.get(userAddress).stream().noneMatch(t -> t.token.equalsIgnoreCase(userAddress))) {
@@ -168,7 +168,7 @@ public class Position extends ButtonCommand<MessageEmbed> {
 
     public static class LongPositions extends AbstractPositions {
 
-        public LongPositions(String userAddress) {
+        public LongPositions(@Nonnull String userAddress) {
             super(userAddress);
         }
 
@@ -268,7 +268,7 @@ public class Position extends ButtonCommand<MessageEmbed> {
                 )
         );
 
-        public CrabPositions(String userAddress) {
+        public CrabPositions(@Nonnull String userAddress) {
             super(userAddress);
         }
 
@@ -491,7 +491,7 @@ public class Position extends ButtonCommand<MessageEmbed> {
         return Arrays.asList(new ItemComponent[]{getButton("Previous"), getButton("Page"), getButton("Next")});
     }
 
-    private void displayPositionPage(EmbedBuilder eb, int page, AbstractPositions[] posArray) {
+    private void displayPositionPage(@Nonnull EmbedBuilder eb, int page, @Nonnull AbstractPositions[] posArray) {
         DecimalFormat df = new DecimalFormat("#");
 
         String priceInUsd = NumberFormat.getInstance().format(posArray[page].currentPriceInUsd.divide(new BigInteger(String.valueOf(df.format(Math.pow(10,18))))).doubleValue() / Math.pow(10,18));

--- a/src/main/java/space/alphaserpentis/squeethdiscordbot/commands/Resources.java
+++ b/src/main/java/space/alphaserpentis/squeethdiscordbot/commands/Resources.java
@@ -138,6 +138,7 @@ public class Resources extends ButtonCommand<MessageEmbed> {
     }
 
     @Override
+    @Nonnull
     public Collection<ItemComponent> addButtons(@Nonnull GenericCommandInteractionEvent event) {
         return Arrays.asList(new ItemComponent[]{getButton("Previous"), getButton("Page"), getButton("Next")});
     }

--- a/src/main/java/space/alphaserpentis/squeethdiscordbot/commands/Settings.java
+++ b/src/main/java/space/alphaserpentis/squeethdiscordbot/commands/Settings.java
@@ -121,7 +121,7 @@ public class Settings extends BotCommand<MessageEmbed> {
         commandId = cmd.getIdLong();
     }
 
-    private void setChangeOnlyEphemeral(long serverId, String input, EmbedBuilder eb) {
+    private void setChangeOnlyEphemeral(long serverId, @Nonnull String input, @Nonnull EmbedBuilder eb) {
         ServerDataHandler.serverDataHashMap.get(serverId).setOnlyEphemeral(Boolean.parseBoolean(input));
 
         try {
@@ -133,7 +133,7 @@ public class Settings extends BotCommand<MessageEmbed> {
         }
     }
 
-    private void setChangeLeaderboard(long serverId, GuildChannelUnion channel, EmbedBuilder eb) {
+    private void setChangeLeaderboard(long serverId, @Nonnull GuildChannelUnion channel, @Nonnull EmbedBuilder eb) {
         ServerDataHandler.serverDataHashMap.get(serverId).setLeaderboardChannelId(channel.getIdLong());
 
         try {
@@ -145,7 +145,7 @@ public class Settings extends BotCommand<MessageEmbed> {
         }
     }
 
-    private void enableRandomQuestions(long serverId, boolean setting, EmbedBuilder eb) {
+    private void enableRandomQuestions(long serverId, boolean setting, @Nonnull EmbedBuilder eb) {
         ServerDataHandler.serverDataHashMap.get(serverId).setDoRandomSquizQuestions(setting);
 
         try {
@@ -163,7 +163,7 @@ public class Settings extends BotCommand<MessageEmbed> {
         }
     }
 
-    private void addChannelFromEligibleChannels(long serverId, GuildChannelUnion channel, EmbedBuilder eb) {
+    private void addChannelFromEligibleChannels(long serverId, @Nonnull GuildChannelUnion channel, @Nonnull EmbedBuilder eb) {
         ServerData sd = ServerDataHandler.serverDataHashMap.get(serverId);
 
         sd.getRandomSquizQuestionsChannels().add(channel.getIdLong());
@@ -178,7 +178,7 @@ public class Settings extends BotCommand<MessageEmbed> {
         }
     }
 
-    private void removeChannelFromEligibleChannels(long serverId, GuildChannelUnion channel, EmbedBuilder eb) {
+    private void removeChannelFromEligibleChannels(long serverId, @Nonnull GuildChannelUnion channel, @Nonnull EmbedBuilder eb) {
         ServerData sd = ServerDataHandler.serverDataHashMap.get(serverId);
 
         boolean result = sd.getRandomSquizQuestionsChannels().remove(channel.getIdLong());
@@ -196,7 +196,7 @@ public class Settings extends BotCommand<MessageEmbed> {
         }
     }
 
-    private void setRandomSquizBaseInterval(long serverId, long interval, EmbedBuilder eb) {
+    private void setRandomSquizBaseInterval(long serverId, long interval, @Nonnull EmbedBuilder eb) {
         ServerData sd = ServerDataHandler.serverDataHashMap.get(serverId);
 
         sd.setRandomSquizBaseIntervals(interval);

--- a/src/main/java/space/alphaserpentis/squeethdiscordbot/commands/Squiz.java
+++ b/src/main/java/space/alphaserpentis/squeethdiscordbot/commands/Squiz.java
@@ -377,7 +377,7 @@ public class Squiz extends ButtonCommand<MessageEmbed> {
         }
     }
 
-    private boolean checkIfCorrectAnswer(char answer, char correctAnswer, SquizSession session) {
+    private boolean checkIfCorrectAnswer(char answer, char correctAnswer, @Nonnull SquizSession session) {
         boolean response = answer == correctAnswer;
 
         if(!response) {
@@ -511,7 +511,7 @@ public class Squiz extends ButtonCommand<MessageEmbed> {
         return questions;
     }
 
-    private static void generateLeaderboard(EmbedBuilder eb, long serverId) {
+    private static void generateLeaderboard(@Nonnull EmbedBuilder eb, long serverId) {
         eb.setTitle("Squiz Leaderboard");
         eb.setDescription("Shows the top 5 people on the leaderboard for the server plus where you are currently in the leaderboard");
         SquizLeaderboard leaderboard = SquizHandler.squizLeaderboardHashMap.getOrDefault(serverId, new SquizLeaderboard());

--- a/src/main/java/space/alphaserpentis/squeethdiscordbot/commands/Squiz.java
+++ b/src/main/java/space/alphaserpentis/squeethdiscordbot/commands/Squiz.java
@@ -4,10 +4,7 @@ package space.alphaserpentis.squeethdiscordbot.commands;
 
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.JDA;
-import net.dv8tion.jda.api.entities.Guild;
-import net.dv8tion.jda.api.entities.Message;
-import net.dv8tion.jda.api.entities.MessageEmbed;
-import net.dv8tion.jda.api.entities.TextChannel;
+import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.events.interaction.command.GenericCommandInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
@@ -408,7 +405,9 @@ public class Squiz extends ButtonCommand<MessageEmbed> {
                     eb.setDescription("You did not earn a point :slight_frown:\n\n" +
                             "The correct answer was " + session.missedQuestions.get(0).answer);
                 } else {
-                    eb.setDescription("You earned a point!");
+                    Guild guild = Launcher.api.getGuildById(((RandomSquizSession) session).serverId);
+                    Member memberWhoAnswered = guild.getMemberById(((RandomSquizSession) session).userWhoResponded);
+                    eb.setDescription(memberWhoAnswered.getAsMention() + " earned a point!");
                     try {
                         updateLeaderboard(((RandomSquizSession) session).serverId);
                         ServerDataHandler.updateServerData();

--- a/src/main/java/space/alphaserpentis/squeethdiscordbot/commands/Vault.java
+++ b/src/main/java/space/alphaserpentis/squeethdiscordbot/commands/Vault.java
@@ -63,8 +63,9 @@ public class Vault extends BotCommand<MessageEmbed> {
             double deltaPerOsqth, gammaPerOsqth, vegaPerOsqth, thetaPerOsqth;
 
             double fundingPeriod = 17.5 / 365;
-            deltaPerOsqth = 2*normFactor*ethUsd*Math.exp(Math.pow(impliedVol, 2)* fundingPeriod)/10000;
-            gammaPerOsqth = 2*normFactor*Math.exp(Math.pow(impliedVol, 2)* fundingPeriod)/10000;
+            double exp = Math.exp(Math.pow(impliedVol, 2) * fundingPeriod);
+            deltaPerOsqth = 2*normFactor*ethUsd*exp/10000;
+            gammaPerOsqth = 2*normFactor*exp/10000;
             vegaPerOsqth = 2*impliedVol* fundingPeriod *osqthUsd;
             thetaPerOsqth = Math.pow(impliedVol, 2)*osqthUsd;
 

--- a/src/main/java/space/alphaserpentis/squeethdiscordbot/commands/Vault.java
+++ b/src/main/java/space/alphaserpentis/squeethdiscordbot/commands/Vault.java
@@ -16,6 +16,7 @@ import org.web3j.abi.datatypes.generated.*;
 import space.alphaserpentis.squeethdiscordbot.handler.EthereumRPCHandler;
 import space.alphaserpentis.squeethdiscordbot.handler.LaevitasHandler;
 
+import javax.annotation.Nonnull;
 import java.awt.*;
 import java.math.BigInteger;
 import java.text.DecimalFormat;
@@ -87,9 +88,9 @@ public class Vault extends BotCommand<MessageEmbed> {
         }
 
         public BigInteger getAmount0Delta(
-                BigInteger sqrtRatioAX96, // uint160
-                BigInteger sqrtRatioBX96, // uint160
-                BigInteger liquidity, // uint128
+                @Nonnull BigInteger sqrtRatioAX96, // uint160
+                @Nonnull BigInteger sqrtRatioBX96, // uint160
+                @Nonnull BigInteger liquidity, // uint128
                 boolean roundUp
         ) throws ExecutionException, InterruptedException {
             Function callGetAmount0Delta = new Function("getAmount0Delta",
@@ -111,9 +112,9 @@ public class Vault extends BotCommand<MessageEmbed> {
         }
 
         public BigInteger getAmount1Delta(
-                BigInteger sqrtRatioAX96, // uint160
-                BigInteger sqrtRatioBX96, // uint160
-                BigInteger liquidity, // uint128
+                @Nonnull BigInteger sqrtRatioAX96, // uint160
+                @Nonnull BigInteger sqrtRatioBX96, // uint160
+                @Nonnull BigInteger liquidity, // uint128
                 boolean roundUp
         ) throws ExecutionException, InterruptedException {
             Function callGetAmount1Delta = new Function("getAmount1Delta",
@@ -135,10 +136,10 @@ public class Vault extends BotCommand<MessageEmbed> {
         }
 
         public Amount0Amount1 getToken0Token1Balances(
-                BigInteger tickLower,
-                BigInteger tickUpper,
-                BigInteger tick,
-                BigInteger liquidity
+                @Nonnull BigInteger tickLower,
+                @Nonnull BigInteger tickUpper,
+                @Nonnull BigInteger tick,
+                @Nonnull BigInteger liquidity
         ) throws ExecutionException, InterruptedException {
             // Call the library because I am not transposing that voodoo magic to Java
             BigInteger sqrtPriceX96 = call_getSqrtRatioAtTick(tick); // uint160
@@ -176,7 +177,7 @@ public class Vault extends BotCommand<MessageEmbed> {
             return amounts;
         }
 
-        private BigInteger call_getSqrtRatioAtTick(BigInteger tick) throws ExecutionException, InterruptedException {
+        private BigInteger call_getSqrtRatioAtTick(@Nonnull BigInteger tick) throws ExecutionException, InterruptedException {
             Function getSqrtRatioAtTick = new Function("getSqrtRatioAtTick",
                     List.of(
                             new Int24(tick)
@@ -396,7 +397,7 @@ public class Vault extends BotCommand<MessageEmbed> {
         commandId = cmd.getIdLong();
     }
 
-    public double calculateCollateralRatio(BigInteger shortoSQTH, BigInteger ethCollateral, BigInteger priceOfETHinUSD, BigInteger normFactor) {
+    public double calculateCollateralRatio(@Nonnull BigInteger shortoSQTH, @Nonnull BigInteger ethCollateral, @Nonnull BigInteger priceOfETHinUSD, @Nonnull BigInteger normFactor) {
         BigInteger debt = shortoSQTH.multiply(priceOfETHinUSD).multiply(normFactor).divide(BigInteger.valueOf(10000));
         // Divide by 10^36 of debt to get the correctly scaled debt
         return ethCollateral.doubleValue() / (debt.doubleValue() / Math.pow(10,36)) * 100;

--- a/src/main/java/space/alphaserpentis/squeethdiscordbot/data/api/alchemy/SimpleTokenTransferResponse.java
+++ b/src/main/java/space/alphaserpentis/squeethdiscordbot/data/api/alchemy/SimpleTokenTransferResponse.java
@@ -2,6 +2,7 @@
 
 package space.alphaserpentis.squeethdiscordbot.data.api.alchemy;
 
+import javax.annotation.Nonnull;
 import java.math.BigInteger;
 import java.text.DecimalFormat;
 
@@ -11,7 +12,7 @@ public class SimpleTokenTransferResponse {
     public String from;
     public double value;
 
-    public SimpleTokenTransferResponse(String token, int blockNum, String from, double value) {
+    public SimpleTokenTransferResponse(@Nonnull String token, int blockNum, @Nonnull String from, double value) {
         this.token = token;
         this.blockNum = blockNum;
         this.from = from;
@@ -21,6 +22,8 @@ public class SimpleTokenTransferResponse {
     public int getBlockNum() {
         return blockNum;
     }
+
+    @Nonnull
     public BigInteger getBigIntegerValue() {
         DecimalFormat df = new DecimalFormat("#");
         double strippedDouble = Double.parseDouble(String.format("%.8f", value));

--- a/src/main/java/space/alphaserpentis/squeethdiscordbot/data/api/alchemy/TokenTransferResponse.java
+++ b/src/main/java/space/alphaserpentis/squeethdiscordbot/data/api/alchemy/TokenTransferResponse.java
@@ -2,21 +2,23 @@
 
 package space.alphaserpentis.squeethdiscordbot.data.api.alchemy;
 
+import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.List;
 
 public class TokenTransferResponse {
     public Result result = new Result();
 
+    @Nonnull
     public List<Result.Transfer> getData() {
         return result.transfers;
     }
 
-    public class Result {   
+    public static class Result {
         public List<Transfer> transfers = new ArrayList<>();
         public String pageKey;
 
-        public class Transfer {
+        public static class Transfer {
             public String blockNum;
             public String from;
             public double value;

--- a/src/main/java/space/alphaserpentis/squeethdiscordbot/data/server/ServerCache.java
+++ b/src/main/java/space/alphaserpentis/squeethdiscordbot/data/server/ServerCache.java
@@ -4,13 +4,14 @@ package space.alphaserpentis.squeethdiscordbot.data.server;
 
 import net.dv8tion.jda.api.entities.Message;
 
+import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.HashMap;
 
 public class ServerCache {
     public static HashMap<Long, ArrayList<Message>> cachedMessages = new HashMap<>();
 
-    public static void addNewMessage(Long guildId, Message message) {
+    public static void addNewMessage(@Nonnull Long guildId, @Nonnull Message message) {
         ArrayList<Message> messages = cachedMessages.get(guildId);
 
         if(messages == null) {
@@ -28,7 +29,7 @@ public class ServerCache {
         }
     }
 
-    public static void removeMessages(Long guildId) {
+    public static void removeMessages(@Nonnull Long guildId) {
         if(cachedMessages.isEmpty()) {
             return;
         }

--- a/src/main/java/space/alphaserpentis/squeethdiscordbot/data/server/squiz/SquizLeaderboard.java
+++ b/src/main/java/space/alphaserpentis/squeethdiscordbot/data/server/squiz/SquizLeaderboard.java
@@ -2,6 +2,7 @@
 
 package space.alphaserpentis.squeethdiscordbot.data.server.squiz;
 
+import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
@@ -17,6 +18,7 @@ public class SquizLeaderboard {
         leaderboard.put(userId, leaderboard.getOrDefault(userId, 0) + 1);
     }
 
+    @Nonnull
     public ArrayList<Long> getTopFive() {
         ArrayList<Long> topFive = new ArrayList<>();
 

--- a/src/main/java/space/alphaserpentis/squeethdiscordbot/handler/CommandsHandler.java
+++ b/src/main/java/space/alphaserpentis/squeethdiscordbot/handler/CommandsHandler.java
@@ -16,7 +16,7 @@ import javax.annotation.Nonnull;
 import java.util.*;
 
 public class CommandsHandler extends ListenerAdapter {
-    public static final HashMap<String, BotCommand> mappingOfCommands = new HashMap<>() {{
+    public static final HashMap<String, BotCommand<?>> mappingOfCommands = new HashMap<>() {{
         put("about", new About());
         put("greeks", new Greeks());
         put("stats", new Stats());
@@ -42,7 +42,7 @@ public class CommandsHandler extends ListenerAdapter {
         for (Iterator<Command> it = listOfActiveCommands.iterator(); it.hasNext(); ) {
             Command cmd = it.next();
             if(mappingOfCommands.containsKey(cmd.getName())) {
-                BotCommand botCmd = mappingOfCommands.get(cmd.getName());
+                BotCommand<?> botCmd = mappingOfCommands.get(cmd.getName());
                 botCmd.setCommandId(cmd.getIdLong());
                 if(updateCommands)
                     botCmd.updateCommand(api);
@@ -66,7 +66,7 @@ public class CommandsHandler extends ListenerAdapter {
 
             for(String cmdName: missingCommands) {
                 System.out.println("[CommandsHandler] Adding new slash command: " + cmdName);
-                BotCommand cmd = mappingOfCommands.get(cmdName);
+                BotCommand<?> cmd = mappingOfCommands.get(cmdName);
                 cmd.addCommand(api);
             }
         }
@@ -76,7 +76,7 @@ public class CommandsHandler extends ListenerAdapter {
     @Override
     public void onSlashCommandInteraction(@Nonnull SlashCommandInteractionEvent event) {
         new Thread(() -> {
-            BotCommand cmd = mappingOfCommands.get(event.getName());
+            BotCommand<?> cmd = mappingOfCommands.get(event.getName());
             Message message;
             message = BotCommand.handleReply(event, cmd);
 
@@ -90,9 +90,9 @@ public class CommandsHandler extends ListenerAdapter {
     @Override
     public void onButtonInteraction(@Nonnull ButtonInteractionEvent event) {
         new Thread(() -> {
-            BotCommand cmd = mappingOfCommands.get(event.getButton().getId().substring(0, event.getButton().getId().indexOf("_")));
+            BotCommand<?> cmd = mappingOfCommands.get(event.getButton().getId().substring(0, event.getButton().getId().indexOf("_")));
 
-            ((ButtonCommand) cmd).runButtonInteraction(event);
+            ((ButtonCommand<?>) cmd).runButtonInteraction(event);
         }).start();
     }
 }

--- a/src/main/java/space/alphaserpentis/squeethdiscordbot/handler/EthereumRPCHandler.java
+++ b/src/main/java/space/alphaserpentis/squeethdiscordbot/handler/EthereumRPCHandler.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public class EthereumRPCHandler {
@@ -36,7 +37,7 @@ public class EthereumRPCHandler {
     public static Web3j web3;
     public static URL url;
 
-    public static List<Type> ethCallAtSpecificBlock(String address, Function function, Long block) throws ExecutionException, InterruptedException {
+    public static List<Type> ethCallAtSpecificBlock(@Nonnull String address, @Nonnull Function function, @Nonnull Long block) throws ExecutionException, InterruptedException {
         return FunctionReturnDecoder.decode(
                 web3.ethCall(Transaction.createEthCallTransaction(
                         zeroAddress,
@@ -47,7 +48,7 @@ public class EthereumRPCHandler {
         );
     }
 
-    public static List<Type> ethCallAtLatestBlock(String address, Function function) throws ExecutionException, InterruptedException {
+    public static List<Type> ethCallAtLatestBlock(@Nonnull String address, @Nonnull Function function) throws ExecutionException, InterruptedException {
         return FunctionReturnDecoder.decode(
                 web3.ethCall(Transaction.createEthCallTransaction(
                         zeroAddress,
@@ -58,7 +59,7 @@ public class EthereumRPCHandler {
         );
     }
 
-    public static ArrayList<SimpleTokenTransferResponse> getAssetTransfersOfUser(String address, String token, long startingBlock, long endingBlock) {
+    public static ArrayList<SimpleTokenTransferResponse> getAssetTransfersOfUser(@Nonnull String address, @Nonnull String token, long startingBlock, long endingBlock) {
         String[] responses = new String[2];
         ArrayList<SimpleTokenTransferResponse> listOfTransfers = new ArrayList<>();
 
@@ -100,7 +101,7 @@ public class EthereumRPCHandler {
         return listOfTransfers;
     }
 
-    public static ArrayList<SimpleTokenTransferResponse> getAssetTransfersOfUser(String address, String token) {
+    public static ArrayList<SimpleTokenTransferResponse> getAssetTransfersOfUser(@Nonnull String address, @Nonnull String token) {
         String[] responses = new String[2];
         ArrayList<SimpleTokenTransferResponse> listOfTransfers = new ArrayList<>();
 
@@ -142,7 +143,7 @@ public class EthereumRPCHandler {
         return listOfTransfers;
     }
 
-    public static String alchemy_getAssetTransfers(String fromAddress, String toAddress, String token, @Nullable String pageKey, long startingBlock, long endingBlock) throws IOException {
+    public static String alchemy_getAssetTransfers(@Nonnull String fromAddress, @Nonnull String toAddress, @Nonnull String token, @Nullable String pageKey, long startingBlock, long endingBlock) throws IOException {
         StringBuilder response = null;
         AlchemyRequest req = new AlchemyRequest();
         Gson gson = new Gson();
@@ -209,7 +210,8 @@ public class EthereumRPCHandler {
         }
     }
 
-    public static String getENSName(String address) {
+    @Nonnull
+    public static String getENSName(@Nonnull String address) {
         EnsResolver resolver = new EnsResolver(web3);
 
         try {
@@ -219,7 +221,7 @@ public class EthereumRPCHandler {
         }
     }
 
-    public static String getResolvedAddress(String ens) throws Exception {
+    public static String getResolvedAddress(@Nonnull String ens) throws Exception {
         EnsResolver resolver = new EnsResolver(web3);
 
         try {

--- a/src/main/java/space/alphaserpentis/squeethdiscordbot/handler/LaevitasHandler.java
+++ b/src/main/java/space/alphaserpentis/squeethdiscordbot/handler/LaevitasHandler.java
@@ -5,6 +5,7 @@ package space.alphaserpentis.squeethdiscordbot.handler;
 import com.google.gson.Gson;
 import space.alphaserpentis.squeethdiscordbot.data.api.SqueethData;
 
+import javax.annotation.Nonnull;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -37,7 +38,7 @@ public class LaevitasHandler {
         }).start();
     }
 
-    public static boolean pollForData(String append) throws IOException {
+    public static boolean pollForData(@Nonnull String append) throws IOException {
         URL fullURL = new URL(API_URL.toString() + append);
 
         HttpURLConnection connection = (HttpURLConnection) fullURL.openConnection();
@@ -71,7 +72,7 @@ public class LaevitasHandler {
         return Instant.now().getEpochSecond() - lastSuccessfulPoll > 600;
     }
 
-    private static void parseData(String data) {
+    private static void parseData(@Nonnull String data) {
         Gson gson = new Gson();
 
         latestSqueethData = gson.fromJson(data, SqueethData.class);

--- a/src/main/java/space/alphaserpentis/squeethdiscordbot/handler/LaevitasHandler.java
+++ b/src/main/java/space/alphaserpentis/squeethdiscordbot/handler/LaevitasHandler.java
@@ -49,7 +49,7 @@ public class LaevitasHandler {
         if(responseCode == HttpURLConnection.HTTP_ACCEPTED || responseCode == HttpURLConnection.HTTP_OK) {
             BufferedReader in = new BufferedReader(new InputStreamReader(connection.getInputStream()));
             String inputLine;
-            StringBuffer response = new StringBuffer();
+            StringBuilder response = new StringBuilder();
 
             while((inputLine = in.readLine()) != null) {
                 response.append(inputLine);

--- a/src/main/java/space/alphaserpentis/squeethdiscordbot/handler/PositionsDataHandler.java
+++ b/src/main/java/space/alphaserpentis/squeethdiscordbot/handler/PositionsDataHandler.java
@@ -10,6 +10,7 @@ import space.alphaserpentis.squeethdiscordbot.data.api.alchemy.SimpleTokenTransf
 import space.alphaserpentis.squeethdiscordbot.handler.serialization.PositionsDataDeserializer;
 import space.alphaserpentis.squeethdiscordbot.handler.serialization.PriceDataDeserializer;
 
+import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.Writer;
@@ -26,7 +27,7 @@ public class PositionsDataHandler {
     public static Path cachedTransfersPath;
     public static Path cachedPricesPath;
 
-    public static void init(Path transfersJson, Path pricesJson) throws IOException {
+    public static void init(@Nonnull Path transfersJson, @Nonnull Path pricesJson) throws IOException {
         Gson gson = new GsonBuilder()
                 .registerTypeAdapter(cachedTransfers.getClass(), new PositionsDataDeserializer())
                 .create();
@@ -46,7 +47,7 @@ public class PositionsDataHandler {
             cachedPrices = new HashMap<>();
     }
 
-    public static void addNewData(String address, ArrayList<SimpleTokenTransferResponse> data) {
+    public static void addNewData(@Nonnull String address, @Nonnull ArrayList<SimpleTokenTransferResponse> data) {
         if(cachedTransfers.containsKey(address)) {
             for(SimpleTokenTransferResponse transfer: data) {
                 if(!cachedTransfers.get(address).contains(transfer)) {
@@ -69,7 +70,7 @@ public class PositionsDataHandler {
         }
     }
 
-    public static void addNewData(Long block, PriceData data) {
+    public static void addNewData(@Nonnull Long block, @Nonnull PriceData data) {
         cachedPrices.put(block, data);
 
         try {
@@ -79,7 +80,7 @@ public class PositionsDataHandler {
         }
     }
 
-    public static void writeDataToFile(Object data, Path path) throws IOException {
+    public static void writeDataToFile(@Nonnull Object data, @Nonnull Path path) throws IOException {
         Writer writer = Files.newBufferedWriter(path);
 
         new Gson().toJson(data, writer);

--- a/src/main/java/space/alphaserpentis/squeethdiscordbot/handler/ServerDataHandler.java
+++ b/src/main/java/space/alphaserpentis/squeethdiscordbot/handler/ServerDataHandler.java
@@ -9,11 +9,11 @@ import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.events.guild.GuildJoinEvent;
 import net.dv8tion.jda.api.events.guild.GuildLeaveEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
-import org.jetbrains.annotations.NotNull;
 import space.alphaserpentis.squeethdiscordbot.data.server.ServerData;
 import space.alphaserpentis.squeethdiscordbot.handler.serialization.ServerDataDeserializer;
 import space.alphaserpentis.squeethdiscordbot.main.Launcher;
 
+import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.Writer;
@@ -28,7 +28,7 @@ public class ServerDataHandler extends ListenerAdapter {
     public static Path serverJson;
     public static HashMap<Long, ServerData> serverDataHashMap = new HashMap<>();
 
-    public static void init(Path jsonFile) throws IOException {
+    public static void init(@Nonnull Path jsonFile) throws IOException {
         Gson gson = new GsonBuilder()
                 .registerTypeAdapter(serverDataHashMap.getClass(), new ServerDataDeserializer())
                 .create();
@@ -63,7 +63,7 @@ public class ServerDataHandler extends ListenerAdapter {
         writeToJSON(gson, gson.toJson(serverDataHashMap));
     }
 
-    private static void writeToJSON(Gson gson, String json) throws IOException {
+    private static void writeToJSON(@Nonnull Gson gson, @Nonnull String json) throws IOException {
         Writer writer = Files.newBufferedWriter(Paths.get(String.valueOf(serverJson)));
 
         gson.toJson(json, writer);
@@ -72,7 +72,7 @@ public class ServerDataHandler extends ListenerAdapter {
     }
 
     @Override
-    public void onGuildJoin(@NotNull GuildJoinEvent event) {
+    public void onGuildJoin(@Nonnull  GuildJoinEvent event) {
         serverDataHashMap.put(event.getGuild().getIdLong(), new ServerData());
         try {
             updateServerData();
@@ -83,7 +83,7 @@ public class ServerDataHandler extends ListenerAdapter {
     }
 
     @Override
-    public void onGuildLeave(@NotNull GuildLeaveEvent event) {
+    public void onGuildLeave(@Nonnull  GuildLeaveEvent event) {
         serverDataHashMap.remove(event.getGuild().getIdLong());
         try {
             updateServerData();

--- a/src/main/java/space/alphaserpentis/squeethdiscordbot/handler/SquizHandler.java
+++ b/src/main/java/space/alphaserpentis/squeethdiscordbot/handler/SquizHandler.java
@@ -12,6 +12,7 @@ import space.alphaserpentis.squeethdiscordbot.data.server.squiz.SquizQuestions;
 import space.alphaserpentis.squeethdiscordbot.handler.serialization.SquizLeaderboardDeserializer;
 import space.alphaserpentis.squeethdiscordbot.handler.serialization.SquizQuestionsDeserializer;
 
+import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.file.Files;
@@ -69,7 +70,7 @@ public class SquizHandler {
         runningRandomSquiz.put(id, t);
     }
 
-    public static void init(Path squizLeaderboardJson, Path squizQuestionsJson) throws IOException {
+    public static void init(@Nonnull Path squizLeaderboardJson, @Nonnull Path squizQuestionsJson) throws IOException {
         SquizHandler.squizLeaderboardJson = squizLeaderboardJson;
         SquizHandler.squizQuestionsJson = squizQuestionsJson;
 
@@ -100,7 +101,7 @@ public class SquizHandler {
         writeToJSON(gson, squizLeaderboardHashMap);
     }
 
-    public static void writeToJSON(Gson gson, Object data) throws IOException {
+    public static void writeToJSON(@Nonnull Gson gson, @Nonnull Object data) throws IOException {
         Path path = Paths.get(squizLeaderboardJson.toString());
         try (Writer writer = Files.newBufferedWriter(path)) {
             gson.toJson(data, writer);

--- a/src/main/java/space/alphaserpentis/squeethdiscordbot/handler/serialization/PositionsDataDeserializer.java
+++ b/src/main/java/space/alphaserpentis/squeethdiscordbot/handler/serialization/PositionsDataDeserializer.java
@@ -19,7 +19,7 @@ public class PositionsDataDeserializer implements JsonDeserializer<Map<String, A
         JsonObject object = jsonElement.getAsJsonObject();
 
         for(Map.Entry<String, JsonElement> entry: object.entrySet()) {
-            positionsDataMap.put(String.valueOf(entry.getKey()), gson.fromJson(entry.getValue(), new ArrayList<SimpleTokenTransferResponse>().getClass()));
+            positionsDataMap.put(String.valueOf(entry.getKey()), gson.fromJson(entry.getValue(), ArrayList.class));
         }
 
         return positionsDataMap;


### PR DESCRIPTION
- Parameterized BotCommand and ButtonCommand references in BotCommand and CommandsHandler with wildcard
- Annotated BotCommand.letMessageExpire
- Check return value inside a block in BotCommand.handleReply
- Made ButtonCommand.buttonHashMap final
- Replaced StringBuffer with StringBuilder in LaevitasHandler
- Removed creating ArrayList object in PositionsDataDeserializer to directly calling the class
- Annotated Nonnulls in ServerCache
- Annotated Nonnull in TokenTransferResponse.getData
- Made TokenTransferResponse.Result and TokenTransferResponse.Result.Transfer static
- Simplified operation in Vault.VaultGreeks.setTheGreeks
- Added BotCommand.handleError to catch any thrown errors from running commands
- Added try/catch statements to capture any thrown exceptions to report to the end-user in BotCommand.handleReply (closes #22 )
- ~~Bump pom.xml to 1.10-test~~
- Bump pom.xml down to 1.9.1
- Improve clarity for who answered the Squiz