### PR TITLE
1.10 - Squiz Redesign

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>space.alphaserpentis</groupId>
     <artifactId>SqueethDiscordBot</artifactId>
-    <version>1.9.2</version>
+    <version>1.10</version>
 
     <properties>
         <maven.compiler.source>14</maven.compiler.source>


### PR DESCRIPTION
- Added expiringThread, responses hashmap, and timeSent in Squiz.RandomSquizSession
- Increased Squiz.messageExpirationLength from 15 to 60 (seconds)
- Added a guild check in Squiz.runCommand
- Rewrote the flow inside Squiz.runButtonInteraction
- Added getAnswerChar in Squiz
- Compressed case for squiz_answer_[answer]
- Added Squiz.randomSquizExpires to handle expiring Squiz questions once triggered
- Swapped Nullable annotation for Nonnull on Squiz.handleNextQuestion after removing Random Squiz logic inside
- Bumped pom.xml from 1.9.2 to 1.10