### PR TITLE
1.12.9 Update - Squiz Manager Commands, Bug Fixes, and QOL Updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target/
 /out/
+/storage/*

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>space.alphaserpentis</groupId>
     <artifactId>SqueethDiscordBot</artifactId>
-    <version>1.12.9-test.1</version>
+    <version>1.12.9-test.2</version>
 
     <properties>
         <maven.compiler.source>14</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>space.alphaserpentis</groupId>
     <artifactId>SqueethDiscordBot</artifactId>
-    <version>1.12.9-test.7</version>
+    <version>1.12.9</version>
 
     <properties>
         <maven.compiler.source>14</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>space.alphaserpentis</groupId>
     <artifactId>SqueethDiscordBot</artifactId>
-    <version>1.12.8</version>
+    <version>1.12.9-test.1</version>
 
     <properties>
         <maven.compiler.source>14</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>space.alphaserpentis</groupId>
     <artifactId>SqueethDiscordBot</artifactId>
-    <version>1.12.9-test.2</version>
+    <version>1.12.9-test.3</version>
 
     <properties>
         <maven.compiler.source>14</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>space.alphaserpentis</groupId>
     <artifactId>SqueethDiscordBot</artifactId>
-    <version>1.12.9-test.5</version>
+    <version>1.12.9-test.6</version>
 
     <properties>
         <maven.compiler.source>14</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>space.alphaserpentis</groupId>
     <artifactId>SqueethDiscordBot</artifactId>
-    <version>1.12.9-test.3</version>
+    <version>1.12.9-test.4</version>
 
     <properties>
         <maven.compiler.source>14</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>space.alphaserpentis</groupId>
     <artifactId>SqueethDiscordBot</artifactId>
-    <version>1.12.9-test.4</version>
+    <version>1.12.9-test.5</version>
 
     <properties>
         <maven.compiler.source>14</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>space.alphaserpentis</groupId>
     <artifactId>SqueethDiscordBot</artifactId>
-    <version>1.12.9-test.6</version>
+    <version>1.12.9-test.7</version>
 
     <properties>
         <maven.compiler.source>14</maven.compiler.source>

--- a/src/main/java/space/alphaserpentis/squeethdiscordbot/commands/About.java
+++ b/src/main/java/space/alphaserpentis/squeethdiscordbot/commands/About.java
@@ -12,9 +12,12 @@ import javax.annotation.Nonnull;
 public class About extends BotCommand<MessageEmbed> {
 
     public About() {
-        name = "about";
-        description = "Description of the bot";
-        onlyEmbed = true;
+        super(new BotCommandOptions(
+            "about",
+            "Description of the bot",
+            true,
+            false
+        ));
     }
 
     @Nonnull

--- a/src/main/java/space/alphaserpentis/squeethdiscordbot/commands/BotCommand.java
+++ b/src/main/java/space/alphaserpentis/squeethdiscordbot/commands/BotCommand.java
@@ -19,10 +19,114 @@ import java.util.HashMap;
 
 public abstract class BotCommand<T> {
 
-    protected HashMap<Long, Long> ratelimitMap = new HashMap<>();
-    protected String name, description;
-    protected long commandId, ratelimitLength, messageExpirationLength;
-    protected boolean onlyEmbed, onlyEphemeral, isActive = true, deferReplies, useRatelimits, messagesExpire;
+    public static class BotCommandOptions {
+        protected final String name;
+        protected final String description;
+        protected final long ratelimitLength;
+        protected final long messageExpirationLength;
+        protected final boolean onlyEmbed;
+        protected final boolean onlyEphemeral;
+        protected final boolean isActive;
+        protected final boolean deferReplies;
+        protected final boolean useRatelimits;
+        protected final boolean messagesExpire;
+        protected long defaultRatelimitLength = 0;
+        protected long defaultMessageExpirationLength = 0;
+        protected boolean defaultOnlyEmbed = false;
+        protected boolean defaultOnlyEphemeral = false;
+        protected boolean defaultIsActive = true;
+        protected boolean defaultDeferReplies = false;
+        protected boolean defaultUseRatelimits = false;
+        protected boolean defaultMessagesExpire = false;
+
+        public BotCommandOptions(
+                @Nonnull String name,
+                @Nonnull String description
+        ) {
+            this.name = name;
+            this.description = description;
+            ratelimitLength = defaultRatelimitLength;
+            messageExpirationLength = defaultMessageExpirationLength;
+            onlyEmbed = defaultOnlyEmbed;
+            onlyEphemeral = defaultOnlyEphemeral;
+            isActive = defaultIsActive;
+            deferReplies = defaultDeferReplies;
+            useRatelimits = defaultUseRatelimits;
+            messagesExpire = defaultMessagesExpire;
+        }
+
+        public BotCommandOptions(
+                @Nonnull String name,
+                @Nonnull String description,
+                boolean onlyEmbed,
+                boolean onlyEphemeral
+        ) {
+            this.name = name;
+            this.description = description;
+            this.onlyEmbed = onlyEmbed;
+            this.onlyEphemeral = onlyEphemeral;
+            ratelimitLength = defaultRatelimitLength;
+            messageExpirationLength = defaultMessageExpirationLength;
+            isActive = defaultIsActive;
+            deferReplies = defaultDeferReplies;
+            useRatelimits = defaultUseRatelimits;
+            messagesExpire = defaultMessagesExpire;
+        }
+
+        public BotCommandOptions(
+                @Nonnull String name,
+                @Nonnull String description,
+                long ratelimitLength,
+                long messageExpirationLength,
+                boolean onlyEmbed,
+                boolean onlyEphemeral,
+                boolean isActive,
+                boolean deferReplies,
+                boolean useRatelimits,
+                boolean messagesExpire
+        ) {
+            this.name = name;
+            this.description = description;
+            this.ratelimitLength = ratelimitLength;
+            this.messageExpirationLength = messageExpirationLength;
+            this.onlyEmbed = onlyEmbed;
+            this.onlyEphemeral = onlyEphemeral;
+            this.isActive = isActive;
+            this.deferReplies = deferReplies;
+            this.useRatelimits = useRatelimits;
+            this.messagesExpire = messagesExpire;
+        }
+    }
+
+    protected final HashMap<Long, Long> ratelimitMap = new HashMap<>();
+    protected final String name;
+    protected final String description;
+    protected final long ratelimitLength;
+    protected final long messageExpirationLength;
+    protected final boolean onlyEmbed;
+    protected final boolean onlyEphemeral;
+    protected final boolean isActive;
+    protected final boolean deferReplies;
+    protected final boolean useRatelimits;
+    protected final boolean messagesExpire;
+    protected long commandId;
+
+    public BotCommand() {
+        throw new RuntimeException("Unsupported constructor");
+    }
+
+    public BotCommand(@Nonnull BotCommandOptions options) {
+        name = options.name;
+        description = options.description;
+        ratelimitLength = options.ratelimitLength;
+        messageExpirationLength = options.messageExpirationLength;
+        onlyEmbed = options.onlyEmbed;
+        onlyEphemeral = options.onlyEphemeral;
+        isActive = options.isActive;
+        deferReplies = options.defaultDeferReplies;
+        useRatelimits = options.useRatelimits;
+        messagesExpire = options.messagesExpire;
+    }
 
     @Nonnull
     abstract public T runCommand(long userId, @Nonnull SlashCommandInteractionEvent event);

--- a/src/main/java/space/alphaserpentis/squeethdiscordbot/commands/ButtonCommand.java
+++ b/src/main/java/space/alphaserpentis/squeethdiscordbot/commands/ButtonCommand.java
@@ -15,13 +15,21 @@ import java.util.HashMap;
 public abstract class ButtonCommand<T> extends BotCommand<T> {
     protected final HashMap<String, Button> buttonHashMap = new HashMap<>();
 
+    public ButtonCommand() {
+        super();
+    }
+
+    public ButtonCommand(@Nonnull BotCommandOptions options) {
+        super(options);
+    }
+
     abstract public void runButtonInteraction(@Nonnull ButtonInteractionEvent event);
     abstract public Collection<ItemComponent> addButtons(@Nonnull GenericCommandInteractionEvent event);
     @Nullable
     public Button getButton(String key) {
         return buttonHashMap.get(key);
     }
-    @Nullable
+    @Nonnull
     public HashMap<String, Button> getButtonHashMap() {
         return buttonHashMap;
     }

--- a/src/main/java/space/alphaserpentis/squeethdiscordbot/commands/Clean.java
+++ b/src/main/java/space/alphaserpentis/squeethdiscordbot/commands/Clean.java
@@ -16,10 +16,12 @@ import javax.annotation.Nonnull;
 public class Clean extends BotCommand<MessageEmbed> {
 
     public Clean() {
-        name = "clean";
-        description = "Cleans the last couple of messages";
-        onlyEmbed = true;
-        onlyEphemeral = true;
+        super(new BotCommandOptions(
+            "clean",
+            "Cleans the last couple of messages",
+            true,
+            true
+        ));
     }
 
     @Nonnull

--- a/src/main/java/space/alphaserpentis/squeethdiscordbot/commands/Crab.java
+++ b/src/main/java/space/alphaserpentis/squeethdiscordbot/commands/Crab.java
@@ -48,9 +48,11 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-public class Crab extends BotCommand<MessageEmbed> {
+import static space.alphaserpentis.squeethdiscordbot.data.ethereum.Addresses.*;
+import static space.alphaserpentis.squeethdiscordbot.data.ethereum.Addresses.Squeeth.*;
+import static space.alphaserpentis.squeethdiscordbot.data.ethereum.Addresses.Uniswap.*;
 
-    private static final String controller = "0x64187ae08781b09368e6253f9e94951243a493d5", oSQTH = "0xf1b99e3e573a1a9c5e6b2ce818b617f0e664e86b", pool = "0x82c427adfdf2d245ec51d8046b41c4ee87f0d29c", ethusdcPool = "0x8ad599c3a0ff1de082011efddc58f1908eb6e6d8", oracle = "0x65d66c76447ccb45daf1e8044e918fa786a483a1", usdc = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", weth = "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2";
+public class Crab extends BotCommand<MessageEmbed> {
 
     public static abstract class CrabVault {
         public static final Function callVaultsFunc = new Function("getVaultDetails",
@@ -64,8 +66,8 @@ public class Crab extends BotCommand<MessageEmbed> {
         );
         public static final Function callUniswapv3TwapOsqth = new Function("getTwap",
                 Arrays.asList(
-                        new org.web3j.abi.datatypes.Address(pool),
-                        new org.web3j.abi.datatypes.Address(oSQTH),
+                        new org.web3j.abi.datatypes.Address(osqthEthPool),
+                        new org.web3j.abi.datatypes.Address(osqth),
                         new org.web3j.abi.datatypes.Address(weth),
                         new Uint32(1),
                         new org.web3j.abi.datatypes.Bool(true)
@@ -77,7 +79,7 @@ public class Crab extends BotCommand<MessageEmbed> {
         );
         public static final Function callUniswapv3TwapEth = new Function("getTwap",
                 Arrays.asList(
-                        new org.web3j.abi.datatypes.Address(ethusdcPool),
+                        new org.web3j.abi.datatypes.Address(ethUsdcPool),
                         new org.web3j.abi.datatypes.Address(weth),
                         new org.web3j.abi.datatypes.Address(usdc),
                         new Uint32(1),
@@ -139,6 +141,7 @@ public class Crab extends BotCommand<MessageEmbed> {
             super("0xf205ad80bb86ac92247638914265887a8baa437d");
         }
 
+        @SuppressWarnings("rawtypes")
         @Override
         public void updateLastHedge() throws IOException {
             EthFilter filter = new EthFilter(new DefaultBlockParameterNumber(15134805), new DefaultBlockParameterNumber(EthereumRPCHandler.web3.ethBlockNumber().send().getBlockNumber()), address)
@@ -450,6 +453,7 @@ public class Crab extends BotCommand<MessageEmbed> {
                 }
             }
 
+            @SuppressWarnings("rawtypes")
             public static double[] estimateSizeOfAuction() {
                 double[] sizes = new double[2];
 
@@ -508,6 +512,7 @@ public class Crab extends BotCommand<MessageEmbed> {
             auction = new Auction();
         }
 
+        @SuppressWarnings("rawtypes")
         @Override
         public void updateLastHedge() throws IOException {
             EthFilter filter = new EthFilter(new DefaultBlockParameterNumber(15134805), new DefaultBlockParameterNumber(EthereumRPCHandler.web3.ethBlockNumber().send().getBlockNumber()), address)
@@ -623,6 +628,7 @@ public class Crab extends BotCommand<MessageEmbed> {
     }
 
     @Nonnull
+    @SuppressWarnings("rawtypes")
     @Override
     public MessageEmbed runCommand(long userId, @Nonnull SlashCommandInteractionEvent event) {
         EmbedBuilder eb = new EmbedBuilder();

--- a/src/main/java/space/alphaserpentis/squeethdiscordbot/commands/Crab.java
+++ b/src/main/java/space/alphaserpentis/squeethdiscordbot/commands/Crab.java
@@ -599,10 +599,18 @@ public class Crab extends BotCommand<MessageEmbed> {
     private static CrabVault crabV1, crabV2;
 
     public Crab() {
-        name = "crab";
-        description = "Get current statistics on the Crab strategy!";
-        onlyEmbed = true;
-        deferReplies = true;
+        super(new BotCommandOptions(
+           "crab",
+           "Get current statistics on the Crab strategy!",
+           0,
+           0,
+           true,
+           false,
+           true,
+           true,
+           false,
+           false
+        ));
 
         try {
             crabV1 = new v1();

--- a/src/main/java/space/alphaserpentis/squeethdiscordbot/commands/Funding.java
+++ b/src/main/java/space/alphaserpentis/squeethdiscordbot/commands/Funding.java
@@ -18,9 +18,12 @@ import java.util.List;
 public class Funding extends BotCommand<MessageEmbed> {
 
     public Funding() {
-        name = "funding";
-        description = "Calculates the estimated amount of funding you would pay (or receive)";
-        onlyEmbed = true;
+        super(new BotCommandOptions(
+           "funding",
+           "Calculates the estimated amount of funding you would pay (or receive)",
+           true,
+           false
+        ));
     }
 
     @Nonnull

--- a/src/main/java/space/alphaserpentis/squeethdiscordbot/commands/Greeks.java
+++ b/src/main/java/space/alphaserpentis/squeethdiscordbot/commands/Greeks.java
@@ -16,9 +16,12 @@ import java.math.BigDecimal;
 public class Greeks extends BotCommand<MessageEmbed> {
 
     public Greeks() {
-        name = "greeks";
-        description = "Display the Greeks for the Squeeth!";
-        onlyEmbed = true;
+        super(new BotCommandOptions(
+                "greeks",
+                "Display the Greeks for the Squeeth!",
+                true,
+                false
+        ));
     }
 
     @Nonnull

--- a/src/main/java/space/alphaserpentis/squeethdiscordbot/commands/Help.java
+++ b/src/main/java/space/alphaserpentis/squeethdiscordbot/commands/Help.java
@@ -15,9 +15,12 @@ import java.awt.*;
 public class Help extends BotCommand<MessageEmbed> {
 
     public Help() {
-        name = "help";
-        description = "Lists all of the available commands";
-        onlyEmbed = true;
+        super(new BotCommandOptions(
+                "help",
+                "Lists all of the available commands",
+                true,
+                false
+        ));
     }
 
     @Nonnull

--- a/src/main/java/space/alphaserpentis/squeethdiscordbot/commands/Position.java
+++ b/src/main/java/space/alphaserpentis/squeethdiscordbot/commands/Position.java
@@ -37,21 +37,18 @@ import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
+import static space.alphaserpentis.squeethdiscordbot.data.ethereum.Addresses.*;
+import static space.alphaserpentis.squeethdiscordbot.data.ethereum.Addresses.Squeeth.*;
+import static space.alphaserpentis.squeethdiscordbot.data.ethereum.Addresses.Uniswap.*;
+
 public class Position extends ButtonCommand<MessageEmbed> {
 
     private static final HashMap<Long, AbstractPositions[]> cachedPositions = new HashMap<>();
     private static final HashMap<String, String> cachedENSDomains = new HashMap<>();
-    private static final String ethUsdPool = "0x8ad599c3a0ff1de082011efddc58f1908eb6e6d8";
-    private static final String ethOsqthPool = "0x82c427adfdf2d245ec51d8046b41c4ee87f0d29c";
-    private static final String usdc = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48";
-    private static final String osqth = "0xf1b99e3e573a1a9c5e6b2ce818b617f0e664e86b";
-    private static final String weth = "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2";
-    private static final String oracle = "0x65d66c76447ccb45daf1e8044e918fa786a483a1";
-    private static final String controller = "0x64187ae08781b09368e6253f9e94951243a493d5";
     private static final Function getTwap_ethUsd = new Function(
                     "getTwap",
                     Arrays.asList(
-                            new org.web3j.abi.datatypes.Address(ethUsdPool),
+                            new org.web3j.abi.datatypes.Address(ethUsdcPool),
                             new org.web3j.abi.datatypes.Address(weth),
                             new org.web3j.abi.datatypes.Address(usdc),
                             new Uint32(1),
@@ -66,7 +63,7 @@ public class Position extends ButtonCommand<MessageEmbed> {
     private static final Function getTwap_osqth = new Function(
             "getTwap",
             Arrays.asList(
-                    new org.web3j.abi.datatypes.Address(ethOsqthPool),
+                    new org.web3j.abi.datatypes.Address(osqthEthPool),
                     new org.web3j.abi.datatypes.Address(osqth),
                     new org.web3j.abi.datatypes.Address(weth),
                     new Uint32(1),
@@ -274,7 +271,7 @@ public class Position extends ButtonCommand<MessageEmbed> {
         );
         private final Function callUniswapv3PriceCheck = new Function("getTwap",
                 Arrays.asList(
-                        new org.web3j.abi.datatypes.Address(ethOsqthPool),
+                        new org.web3j.abi.datatypes.Address(osqthEthPool),
                         new org.web3j.abi.datatypes.Address(osqth),
                         new org.web3j.abi.datatypes.Address(weth),
                         new Uint32(1),
@@ -287,7 +284,7 @@ public class Position extends ButtonCommand<MessageEmbed> {
         );
         private final Function callUniswapv3PriceCheck_USDC = new Function("getTwap",
                 Arrays.asList(
-                        new org.web3j.abi.datatypes.Address(ethUsdPool),
+                        new org.web3j.abi.datatypes.Address(ethUsdcPool),
                         new org.web3j.abi.datatypes.Address(weth),
                         new org.web3j.abi.datatypes.Address(usdc),
                         new Uint32(1),
@@ -312,6 +309,7 @@ public class Position extends ButtonCommand<MessageEmbed> {
             this.isV2 = isV2;
         }
 
+        @SuppressWarnings("rawtypes")
         @Override
         public void getAndSetPrices() {
             try {
@@ -336,6 +334,7 @@ public class Position extends ButtonCommand<MessageEmbed> {
             }
         }
 
+        @SuppressWarnings("rawtypes")
         @Override
         public void calculateCostBasis() {
             DecimalFormat df = new DecimalFormat("#");

--- a/src/main/java/space/alphaserpentis/squeethdiscordbot/commands/Position.java
+++ b/src/main/java/space/alphaserpentis/squeethdiscordbot/commands/Position.java
@@ -367,13 +367,18 @@ public class Position extends ButtonCommand<MessageEmbed> {
     }
 
     public Position() {
-        name = "position";
-        description = "Checks your wallet's Squeeth position";
-        onlyEmbed = true;
-        onlyEphemeral = true;
-        deferReplies = true;
-        useRatelimits = true;
-        ratelimitLength = 60;
+        super(new BotCommandOptions(
+            "position",
+            "Checks your wallet's long Squeeth and Crab v1/v2 positions",
+            60,
+            0,
+            true,
+            true,
+            true,
+            true,
+            true,
+            false
+        ));
 
         buttonHashMap.put("Previous", Button.primary("position_previous", "Previous").asDisabled());
         buttonHashMap.put("Page", Button.secondary("position_page", "1/3").asDisabled());

--- a/src/main/java/space/alphaserpentis/squeethdiscordbot/commands/Resources.java
+++ b/src/main/java/space/alphaserpentis/squeethdiscordbot/commands/Resources.java
@@ -62,10 +62,12 @@ public class Resources extends ButtonCommand<MessageEmbed> {
     }};
 
     public Resources() {
-        name = "resources";
-        description = "Obtain educational resources all about Squeeth!";
-        onlyEmbed = true;
-        onlyEphemeral = true;
+        super(new BotCommandOptions(
+           "resoures",
+           "Obtain educational resources all about Squeeth!",
+           true,
+           true
+        ));
 
         buttonHashMap.put("Previous", Button.primary("resources_previous", "Previous").asDisabled());
         buttonHashMap.put("Page", Button.secondary("resources_page", "1/" + pages.size()).asDisabled());

--- a/src/main/java/space/alphaserpentis/squeethdiscordbot/commands/Settings.java
+++ b/src/main/java/space/alphaserpentis/squeethdiscordbot/commands/Settings.java
@@ -46,9 +46,12 @@ public class Settings extends BotCommand<MessageEmbed> {
     private static final String error = "An error occurred, please try again later. If this persists, please contact AlphaSerpentis#3203 at discord.gg/opyn";
 
     public Settings() {
-        name = "settings";
-        description = "Configure the server settings";
-        onlyEmbed = true;
+        super(new BotCommandOptions(
+           "settings",
+           "Configure the server settings",
+           true,
+           false
+        ));
     }
 
     @Nonnull

--- a/src/main/java/space/alphaserpentis/squeethdiscordbot/commands/Squiz.java
+++ b/src/main/java/space/alphaserpentis/squeethdiscordbot/commands/Squiz.java
@@ -489,7 +489,7 @@ public class Squiz extends ButtonCommand<MessageEmbed> {
 
         Message message = channelRand.sendMessageEmbeds(eb.build()).setActionRow(buttons).complete();
         session.message = message;
-        ServerCache.addNewMessage(message.getChannel().getIdLong(), message.getIdLong());
+        ServerCache.addNewMessage(message.getGuild().getIdLong(), message.getChannel().getIdLong(), message.getIdLong());
     }
 
     public void updateLeaderboard(long serverId) throws NullPointerException {

--- a/src/main/java/space/alphaserpentis/squeethdiscordbot/commands/Squiz.java
+++ b/src/main/java/space/alphaserpentis/squeethdiscordbot/commands/Squiz.java
@@ -489,7 +489,7 @@ public class Squiz extends ButtonCommand<MessageEmbed> {
 
         Message message = channelRand.sendMessageEmbeds(eb.build()).setActionRow(buttons).complete();
         session.message = message;
-        ServerCache.addNewMessage(serverId, message);
+        ServerCache.addNewMessage(message.getChannel().getIdLong(), message.getIdLong());
     }
 
     public void updateLeaderboard(long serverId) throws NullPointerException {

--- a/src/main/java/space/alphaserpentis/squeethdiscordbot/commands/Squiz.java
+++ b/src/main/java/space/alphaserpentis/squeethdiscordbot/commands/Squiz.java
@@ -202,10 +202,10 @@ public class Squiz extends ButtonCommand<MessageEmbed> {
                 case "clear_leaderboard" -> {
                     if(verifyManageServerPerms(event.getMember())) {
                         eb.setDescription("**Are you sure you want to clear the leaderboard?**\n\n**THIS IS IRREVERSIBLE**");
+                        session.currentState = States.PENDING_CONFIRMATION;
                     } else {
                         eb.setDescription("Insufficient permissions");
                     }
-                    return eb.build();
                 }
             }
         }
@@ -400,8 +400,19 @@ public class Squiz extends ButtonCommand<MessageEmbed> {
                 buttons.add(Button.secondary("squiz_page", viewingSession.currentPage + 1 + "/" + viewingSession.pages.size()).asDisabled());
             }
             case "squiz_confirm" -> {
-                squizSessionHashMap.remove(userId);
-                eb.setDescription("Leaderboard cleared");
+                SquizLeaderboard squizLeaderboard = SquizHandler.squizLeaderboardHashMap.get(serverId);
+
+                squizLeaderboard.leaderboard.clear();
+                updateLeaderboard(serverId);
+                try {
+                    SquizHandler.updateSquizLeaderboard();
+                    eb.setDescription("Leaderboard cleared");
+                } catch (IOException e) {
+                    e.printStackTrace();
+                    eb.setDescription("Leaderboard cleared, but not updated on disk!");
+                } finally {
+                    squizSessionHashMap.remove(userId);
+                }
             }
             case "squiz_cancel" -> {
                 squizSessionHashMap.remove(userId);

--- a/src/main/java/space/alphaserpentis/squeethdiscordbot/commands/Stats.java
+++ b/src/main/java/space/alphaserpentis/squeethdiscordbot/commands/Stats.java
@@ -17,9 +17,12 @@ import java.text.NumberFormat;
 public class Stats extends BotCommand<MessageEmbed> {
 
     public Stats() {
-        name = "stats";
-        description = "Get current statistics on Squeeth!";
-        onlyEmbed = true;
+        super(new BotCommandOptions(
+            "stats",
+            "Get current statistics on Squeeth",
+            true,
+            false
+        ));
     }
 
     @Nonnull

--- a/src/main/java/space/alphaserpentis/squeethdiscordbot/commands/Vault.java
+++ b/src/main/java/space/alphaserpentis/squeethdiscordbot/commands/Vault.java
@@ -26,9 +26,13 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
-public class Vault extends BotCommand<MessageEmbed> {
+import static space.alphaserpentis.squeethdiscordbot.data.ethereum.Addresses.Squeeth.controller;
+import static space.alphaserpentis.squeethdiscordbot.data.ethereum.Addresses.Uniswap.ethUsdcPool;
+import static space.alphaserpentis.squeethdiscordbot.data.ethereum.Addresses.Uniswap.oracle;
+import static space.alphaserpentis.squeethdiscordbot.data.ethereum.Addresses.usdc;
+import static space.alphaserpentis.squeethdiscordbot.data.ethereum.Addresses.weth;
 
-    private static final String controller = "0x64187ae08781b09368e6253f9e94951243a493d5";
+public class Vault extends BotCommand<MessageEmbed> {
 
     public static class VaultGreeks {
         private final double ethUsd;
@@ -87,6 +91,7 @@ public class Vault extends BotCommand<MessageEmbed> {
             BigInteger amount1 = BigInteger.ZERO;
         }
 
+        @SuppressWarnings("rawtypes")
         public BigInteger getAmount0Delta(
                 @Nonnull BigInteger sqrtRatioAX96, // uint160
                 @Nonnull BigInteger sqrtRatioBX96, // uint160
@@ -111,6 +116,7 @@ public class Vault extends BotCommand<MessageEmbed> {
             return (BigInteger) response.get(0).getValue();
         }
 
+        @SuppressWarnings("rawtypes")
         public BigInteger getAmount1Delta(
                 @Nonnull BigInteger sqrtRatioAX96, // uint160
                 @Nonnull BigInteger sqrtRatioBX96, // uint160
@@ -177,6 +183,7 @@ public class Vault extends BotCommand<MessageEmbed> {
             return amounts;
         }
 
+        @SuppressWarnings("rawtypes")
         private BigInteger call_getSqrtRatioAtTick(@Nonnull BigInteger tick) throws ExecutionException, InterruptedException {
             Function getSqrtRatioAtTick = new Function("getSqrtRatioAtTick",
                     List.of(
@@ -208,6 +215,7 @@ public class Vault extends BotCommand<MessageEmbed> {
     }
 
     @NotNull
+    @SuppressWarnings("rawtypes")
     @Override
     public MessageEmbed runCommand(long userId, @NotNull SlashCommandInteractionEvent event) {
         EmbedBuilder eb = new EmbedBuilder();
@@ -235,9 +243,9 @@ public class Vault extends BotCommand<MessageEmbed> {
         );
         Function callUniswapv3PriceCheck = new Function("getTwap",
                 Arrays.asList(
-                        new org.web3j.abi.datatypes.Address("0x8ad599c3a0ff1de082011efddc58f1908eb6e6d8"),
-                        new org.web3j.abi.datatypes.Address("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"),
-                        new org.web3j.abi.datatypes.Address("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"),
+                        new org.web3j.abi.datatypes.Address(ethUsdcPool),
+                        new org.web3j.abi.datatypes.Address(weth),
+                        new org.web3j.abi.datatypes.Address(usdc),
                         new Uint32(1),
                         new org.web3j.abi.datatypes.Bool(true)
                 ),
@@ -273,8 +281,8 @@ public class Vault extends BotCommand<MessageEmbed> {
 
         try {
             vaultsResponse = EthereumRPCHandler.ethCallAtLatestBlock(controller, callVaults);
-            priceOfEthResponse = EthereumRPCHandler.ethCallAtLatestBlock("0x65d66c76447ccb45daf1e8044e918fa786a483a1", callUniswapv3PriceCheck);
-            tickOfoSQTHPoolResponse = EthereumRPCHandler.ethCallAtLatestBlock("0x65d66c76447ccb45daf1e8044e918fa786a483a1", callUniswapv3Tick);
+            priceOfEthResponse = EthereumRPCHandler.ethCallAtLatestBlock(oracle, callUniswapv3PriceCheck);
+            tickOfoSQTHPoolResponse = EthereumRPCHandler.ethCallAtLatestBlock(oracle, callUniswapv3Tick);
             Uniswapv3FuckYouMath univ3 = new Uniswapv3FuckYouMath();
 
             address = (String) vaultsResponse.get(0).getValue();

--- a/src/main/java/space/alphaserpentis/squeethdiscordbot/commands/Vault.java
+++ b/src/main/java/space/alphaserpentis/squeethdiscordbot/commands/Vault.java
@@ -193,13 +193,18 @@ public class Vault extends BotCommand<MessageEmbed> {
     }
 
     public Vault() {
-        name = "vault";
-        description = "Display info on a certain short vault";
-        onlyEmbed = true;
-        onlyEphemeral = true;
-        deferReplies = true;
-        useRatelimits = true;
-        ratelimitLength = 60;
+        super(new BotCommandOptions(
+            "vault",
+            "Display info on a certain short vault",
+            60,
+            0,
+            true,
+            true,
+            true,
+            true,
+            true,
+            false
+        ));
     }
 
     @NotNull

--- a/src/main/java/space/alphaserpentis/squeethdiscordbot/data/api/PriceData.java
+++ b/src/main/java/space/alphaserpentis/squeethdiscordbot/data/api/PriceData.java
@@ -9,4 +9,5 @@ public class PriceData {
     public BigInteger osqthEth = BigInteger.ZERO;
     public BigInteger crabEth = BigInteger.ZERO;
     public BigInteger crabV2Eth = BigInteger.ZERO;
+    public BigInteger normFactor = BigInteger.ZERO;
 }

--- a/src/main/java/space/alphaserpentis/squeethdiscordbot/data/ethereum/Addresses.java
+++ b/src/main/java/space/alphaserpentis/squeethdiscordbot/data/ethereum/Addresses.java
@@ -1,0 +1,19 @@
+package space.alphaserpentis.squeethdiscordbot.data.ethereum;
+
+public interface Addresses {
+    String zeroAddress = "0x0000000000000000000000000000000000000000";
+    String weth = "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2";
+    String usdc = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48";
+
+    interface Squeeth {
+        String controller = "0x64187ae08781b09368e6253f9e94951243a493d5";
+        String osqth = "0xf1b99e3e573a1a9c5e6b2ce818b617f0e664e86b";
+    }
+
+    interface Uniswap {
+        String osqthEthPool = "0x82c427adfdf2d245ec51d8046b41c4ee87f0d29c";
+        String ethUsdcPool = "0x8ad599c3a0ff1de082011efddc58f1908eb6e6d8";
+        String oracle = "0x65d66c76447ccb45daf1e8044e918fa786a483a1";
+    }
+
+}

--- a/src/main/java/space/alphaserpentis/squeethdiscordbot/data/server/ServerCache.java
+++ b/src/main/java/space/alphaserpentis/squeethdiscordbot/data/server/ServerCache.java
@@ -2,43 +2,50 @@
 
 package space.alphaserpentis.squeethdiscordbot.data.server;
 
-import net.dv8tion.jda.api.entities.Message;
+import space.alphaserpentis.squeethdiscordbot.main.Launcher;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.HashMap;
 
 public class ServerCache {
-    public static HashMap<Long, ArrayList<Message>> cachedMessages = new HashMap<>();
+    public static HashMap<Long, ArrayList<Long>> cachedMessages = new HashMap<>();
 
-    public static void addNewMessage(@Nonnull Long guildId, @Nonnull Message message) {
-        ArrayList<Message> messages = cachedMessages.get(guildId);
+    public static void addNewMessage(@Nonnull Long channelId, @Nonnull Long messageId) {
+        ArrayList<Long> messages = cachedMessages.get(channelId);
 
         if(messages == null) {
             messages = new ArrayList<>();
 
-            messages.add(message);
+            messages.add(messageId);
 
-            cachedMessages.put(guildId, messages);
+            cachedMessages.put(channelId, messages);
         } else if(messages.size() == 10){
             messages.remove(0);
-            messages.add(message);
+            messages.add(messageId);
         } else {
-            messages.add(message);
+            messages.add(messageId);
 
         }
     }
 
-    public static void removeMessages(@Nonnull Long guildId) {
+    public static void removeMessages(@Nonnull Long channelId) {
         if(cachedMessages.isEmpty()) {
             return;
         }
 
-        for(Message msg: cachedMessages.get(guildId)) {
-            msg.delete().queue();
+        for(Long msgId: cachedMessages.get(channelId)) {
+            try {
+                Launcher.api.getGuildChannelById(channelId).getGuild().getTextChannelById(channelId).retrieveMessageById(msgId).queue(
+                        (success) -> success.delete().complete(),
+                        (ignored) -> {}
+                );
+            } catch(NullPointerException ignored) {
+
+            }
         }
 
-        cachedMessages.get(guildId).clear();
+        cachedMessages.get(channelId).clear();
     }
 
 }

--- a/src/main/java/space/alphaserpentis/squeethdiscordbot/handler/CommandsHandler.java
+++ b/src/main/java/space/alphaserpentis/squeethdiscordbot/handler/CommandsHandler.java
@@ -87,7 +87,7 @@ public class CommandsHandler extends ListenerAdapter {
             message = BotCommand.handleReply(event, cmd);
 
             if(event.getGuild() != null && !message.isEphemeral()) {
-                ServerCache.addNewMessage(event.getGuild().getIdLong(), message);
+                ServerCache.addNewMessage(message.getChannel().getIdLong(), message.getIdLong());
             }
         });
     }

--- a/src/main/java/space/alphaserpentis/squeethdiscordbot/handler/CommandsHandler.java
+++ b/src/main/java/space/alphaserpentis/squeethdiscordbot/handler/CommandsHandler.java
@@ -87,7 +87,7 @@ public class CommandsHandler extends ListenerAdapter {
             message = BotCommand.handleReply(event, cmd);
 
             if(event.getGuild() != null && !message.isEphemeral()) {
-                ServerCache.addNewMessage(message.getChannel().getIdLong(), message.getIdLong());
+                ServerCache.addNewMessage(message.getGuild().getIdLong(), message.getChannel().getIdLong(), message.getIdLong());
             }
         });
     }

--- a/src/main/java/space/alphaserpentis/squeethdiscordbot/handler/EthereumRPCHandler.java
+++ b/src/main/java/space/alphaserpentis/squeethdiscordbot/handler/EthereumRPCHandler.java
@@ -15,6 +15,7 @@ import org.web3j.protocol.core.methods.request.Transaction;
 import space.alphaserpentis.squeethdiscordbot.data.api.alchemy.AlchemyRequest;
 import space.alphaserpentis.squeethdiscordbot.data.api.alchemy.SimpleTokenTransferResponse;
 import space.alphaserpentis.squeethdiscordbot.data.api.alchemy.TokenTransferResponse;
+import space.alphaserpentis.squeethdiscordbot.data.ethereum.Addresses;
 
 import java.io.BufferedReader;
 import java.io.DataOutputStream;
@@ -33,14 +34,14 @@ import javax.annotation.Nullable;
 
 public class EthereumRPCHandler {
 
-    public static final String zeroAddress = "0x0000000000000000000000000000000000000000";
     public static Web3j web3;
     public static URL url;
 
+    @SuppressWarnings("rawtypes")
     public static List<Type> ethCallAtSpecificBlock(@Nonnull String address, @Nonnull Function function, @Nonnull Long block) throws ExecutionException, InterruptedException {
         return FunctionReturnDecoder.decode(
                 web3.ethCall(Transaction.createEthCallTransaction(
-                        zeroAddress,
+                        Addresses.zeroAddress,
                         address,
                         FunctionEncoder.encode(function)
                 ), new DefaultBlockParameterNumber(block)).sendAsync().get().getResult(),
@@ -48,10 +49,11 @@ public class EthereumRPCHandler {
         );
     }
 
+    @SuppressWarnings("rawtypes")
     public static List<Type> ethCallAtLatestBlock(@Nonnull String address, @Nonnull Function function) throws ExecutionException, InterruptedException {
         return FunctionReturnDecoder.decode(
                 web3.ethCall(Transaction.createEthCallTransaction(
-                        zeroAddress,
+                        Addresses.zeroAddress,
                         address,
                         FunctionEncoder.encode(function)
                 ), DefaultBlockParameterName.LATEST).sendAsync().get().getResult(),


### PR DESCRIPTION
- Added commands to clear the leaderboard
- Ability to manually add or remove points from a user in the Squiz
- `PriceData` now collects norm factor
- Added an `Addresses` interface to contain common addresses used for dapps and Squeeth
- Added a funding paid estimator for long positions
- Fixed `clean` command to utilize long IDs instead of the `Message` object
- Backend optimizations and QOL changes

Closes #35 